### PR TITLE
Update a link to the latest commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Users of the plugin upgrading from previous versions of RabbitMQ should:
 For users of RabbitMQ 3.4.x, you can read the old version
 of the README at:
 
-https://github.com/rabbitmq/rabbitmq-priority-queue/tree/3431dc1ef8ea53e9a556c6be8bc1b417ac03b58d
+https://github.com/rabbitmq/rabbitmq-priority-queue/tree/fbdcb67af2d190d3974a8133096be2f3f576ee62
 
 and download the plugin from:
 


### PR DESCRIPTION
Just a minor correction of a README so that it points at the latest backported commit. This is to not confuse other developers looking for the older code.

Thank you for keeping the code available!