### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ https://github.com/rabbitmq/rabbitmq-priority-queue/tree/fbdcb67af2d190d3974a813
 
 and download the plugin from:
 
-http://www.rabbitmq.com/community-plugins/
+https://www.rabbitmq.com/community-plugins/
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.rabbitmq.com/community-plugins/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/community-plugins/ ([https](https://www.rabbitmq.com/community-plugins/) result 200).